### PR TITLE
[Fix](App crash with NPE on signed build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following requirements must be set up before installing Chargebee’s Androi
 The `Chargebee-Android` SDK can be installed by adding below dependency to the `build.gradle` file:
 
 ```kotlin
-implementation 'com.chargebee:chargebee-android:1.0.14'
+implementation 'com.chargebee:chargebee-android:1.0.15'
 ```
 
 ## Example project
@@ -365,7 +365,7 @@ Chargebee is available under the [MIT license](https://opensource.org/licenses/M
   To install Chargebee's Android SDK, add the following dependency to the build.gradle file.
   
   ```
-  implementation 'com.chargebee:chargebee-android:1.0.14'
+  implementation 'com.chargebee:chargebee-android:1.0.15'
   ```
   Example project
   ---------------

--- a/chargebee/build.gradle
+++ b/chargebee/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 1
-        versionName "1.0.14"
+        versionName "1.0.15"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/chargebee/src/main/java/com/chargebee/android/models/ResultHandler.kt
+++ b/chargebee/src/main/java/com/chargebee/android/models/ResultHandler.kt
@@ -39,7 +39,7 @@ internal class ResultHandler {
             logger: CBLogger? = null
         ) {
             try {
-                CoroutineScope(Dispatchers.IO).launch {
+                CoroutineScope(Dispatchers.IO + coroutineExceptionHandler()).launch {
                     val result: ChargebeeResult<T> = try {
                         logger?.info()
                         codeBlock()
@@ -61,11 +61,11 @@ internal class ResultHandler {
             }
 
         }
-//        private fun coroutineExceptionHandler() : CoroutineExceptionHandler {
-//            val coroutineExceptionHandler = CoroutineExceptionHandler{_, throwable ->
-//                print("CoroutineExceptionHandler: ${throwable.message}")
-//            }
-//            return coroutineExceptionHandler
-//        }
+        private fun coroutineExceptionHandler() : CoroutineExceptionHandler {
+            val coroutineExceptionHandler = CoroutineExceptionHandler{_, throwable ->
+                print("CoroutineExceptionHandler : ${throwable.message}")
+            }
+            return coroutineExceptionHandler
+        }
     }
 }


### PR DESCRIPTION
Issue: App got crashed on release with signed apk
Resolution: Basically normal function will get re-throw the exception but its not the case in Coroutines due to that App got crashed in ResultHandler Coroutine scope which is the root of the coroutines function.