### PR TITLE
[Fix](Fetch plans with no params)

### DIFF
--- a/app/src/main/java/com/chargebee/example/plan/PlansActivity.kt
+++ b/app/src/main/java/com/chargebee/example/plan/PlansActivity.kt
@@ -32,7 +32,7 @@ class PlansActivity : BaseActivity(), ItemsAdapter.ItemClickListener {
         this.mErrorTextView = findViewById(R.id.errorMessage)
         viewModel = PlanViewModel()
         showProgressDialog()
-        val queryParam = arrayOf("Standard", Chargebee.channel)
+        val queryParam = arrayOf("10")
         viewModel!!.retrieveAllPlans(queryParam)
 
         viewModel?.mPlansResult?.observe(this, Observer {

--- a/chargebee/src/main/java/com/chargebee/android/Chargebee.kt
+++ b/chargebee/src/main/java/com/chargebee/android/Chargebee.kt
@@ -139,7 +139,7 @@ object Chargebee {
     /* Get the Plan details from chargebee system */
     @Throws(InvalidRequestException::class, OperationFailedException::class)
     fun retrievePlan(planId: String, completion : (ChargebeeResult<Any>) -> Unit) {
-        val logger = CBLogger(name = "plan", action = "getAllPlan")
+        val logger = CBLogger(name = "plan", action = "getPlan")
         if (TextUtils.isEmpty(planId))
             completion(ChargebeeResult.Error(
                 exp = CBException(
@@ -152,16 +152,23 @@ object Chargebee {
 
     /* Get the list of Plan's from chargebee system */
     @Throws(InvalidRequestException::class, OperationFailedException::class)
-    fun retrieveAllPlans(params: Array<String>, completion : (ChargebeeResult<Any>) -> Unit) {
-        val logger = CBLogger(name = "plans", action = "getPlan")
-        if (params.isNullOrEmpty())
-            completion(ChargebeeResult.Error(
-                exp = CBException(
-                    error = ErrorDetail(message = "Query param is empty", apiErrorCode = "400")
+    fun retrieveAllPlans(params: Array<String> = arrayOf(), completion : (ChargebeeResult<Any>) -> Unit) {
+        val logger = CBLogger(name = "plans", action = "getAllPlan")
+        if (params.isNotEmpty()) {
+            ResultHandler.safeExecuter(
+                { PlanResource().retrieveAllPlans(params) },
+                completion,
+                logger
+            )
+        } else {
+            ResultHandler.safeExecuter({
+                PlanResource().retrieveAllPlans(
+                    arrayOf(
+                        limit
+                    )
                 )
-            ))
-        else
-            ResultHandler.safeExecuter({ PlanResource().retrieveAllPlans(params) }, completion, logger)
+            }, completion, logger)
+        }
     }
 
     /* Get the list of Items's from chargebee system */

--- a/chargebee/src/main/java/com/chargebee/android/billingservice/CBPurchase.kt
+++ b/chargebee/src/main/java/com/chargebee/android/billingservice/CBPurchase.kt
@@ -38,7 +38,7 @@ object CBPurchase {
             params[0] = params[0].ifEmpty { Chargebee.limit }
             val queryParams = append(params)
             retrieveProductIDList(queryParams, completion)
-        }else{retrieveProductIDList(arrayOf(Chargebee.limit,"Standard"), completion) }
+        }else{retrieveProductIDList(arrayOf(), completion) }
     }
     /* Get the product/sku details from Play console */
     @JvmStatic

--- a/chargebee/src/main/java/com/chargebee/android/repository/PlanRepository.kt
+++ b/chargebee/src/main/java/com/chargebee/android/repository/PlanRepository.kt
@@ -25,7 +25,8 @@ internal interface PlanRepository {
         @Header("Authorization") token: String = Chargebee.encodedApiKey,
         @Header("platform") platform: String = Chargebee.platform,
         @Header("version") sdkVersion: String = Chargebee.sdkVersion,
-        @Query("sort_by[desc]") sort: String,
-        @Query("channel[is]") channel: String
+        @Query("limit") limit: String = "",
+        @Query("sort_by[desc]") sort: String = "Standard",
+        @Query("channel[is]") channel: String = Chargebee.channel
     ): Response<PlansWrapper?>
 }

--- a/chargebee/src/main/java/com/chargebee/android/repository/PlanRepository.kt
+++ b/chargebee/src/main/java/com/chargebee/android/repository/PlanRepository.kt
@@ -25,7 +25,7 @@ internal interface PlanRepository {
         @Header("Authorization") token: String = Chargebee.encodedApiKey,
         @Header("platform") platform: String = Chargebee.platform,
         @Header("version") sdkVersion: String = Chargebee.sdkVersion,
-        @Query("limit") limit: String = "",
+        @Query("limit") limit: String = Chargebee.limit,
         @Query("sort_by[desc]") sort: String = "Standard",
         @Query("channel[is]") channel: String = Chargebee.channel
     ): Response<PlansWrapper?>

--- a/chargebee/src/main/java/com/chargebee/android/resources/PlanResource.kt
+++ b/chargebee/src/main/java/com/chargebee/android/resources/PlanResource.kt
@@ -18,7 +18,7 @@ internal class PlanResource: BaseResource(Chargebee.baseUrl) {
     }
 
     suspend fun retrieveAllPlans(params: Array<String>): ChargebeeResult<Any> {
-        val itemsResponse = apiClient.create(PlanRepository::class.java).retrieveAllPlans(sort = params.get(0), channel = params.get(1))
+        val itemsResponse = apiClient.create(PlanRepository::class.java).retrieveAllPlans(limit = params[0])
 
         Log.i(javaClass.simpleName, " Response :$itemsResponse")
         return responseFromServer(

--- a/chargebee/src/test/java/com/chargebee/android/resources/PlanResourceTest.kt
+++ b/chargebee/src/test/java/com/chargebee/android/resources/PlanResourceTest.kt
@@ -23,36 +23,31 @@ import java.util.concurrent.CountDownLatch
 
 @RunWith(MockitoJUnitRunner::class)
 class PlanResourceTest {
-
+    private var queryParam = arrayOf("5")
+    private var lock = CountDownLatch(1)
+    private var exception = CBException(ErrorDetail("Error"))
+    private var planId = "Standard"
     @Before
     fun setUp(){
         MockitoAnnotations.initMocks(this)
         Chargebee.configure(
-            site = "cb-imay-test",
-            publishableApiKey = "test_EojsGoGFeHoc3VpGPQDOZGAxYy3d0FF3",
-            sdkKey = "cb-j53yhbfmtfhfhkmhow3ramecom"
+            site = "site-name",
+            publishableApiKey = "api-key",
+            sdkKey = "sdk-key"
         )
 
     }
     @After
     fun tearDown(){
-
+        lock = CountDownLatch(0)
     }
     @Test
     fun test_retrievePlansList_success(){
-        val plan = Plan(
-            "id", "name", "invoice", 123, 123, "", "",
-            12, 23, "", false, false, "false", false,
-            9, false, "app_store", 7, "", "", false, "", false, false
-        )
-
-        val queryParam = arrayOf("Standard", "app_store")
-        val lock = CountDownLatch(1)
-        Plan.retrieveAllPlans(queryParam) {
+        Chargebee.retrieveAllPlans(queryParam) {
             when (it) {
                 is ChargebeeResult.Success -> {
                     lock.countDown()
-                    System.out.println("List plans :"+it.data)
+                    print("List plans :"+it.data)
                     MatcherAssert.assertThat(
                         (it.data),
                         Matchers.instanceOf(PlansWrapper::class.java)
@@ -60,16 +55,15 @@ class PlanResourceTest {
                 }
                 is ChargebeeResult.Error -> {
                     lock.countDown()
-                    System.out.println("Error :"+it.exp.message)
+                    print("Error :"+it.exp.message)
                 }
             }
         }
         lock.await()
-
         CoroutineScope(Dispatchers.IO).launch {
             Mockito.`when`(PlanResource().retrieveAllPlans(queryParam)).thenReturn(
                 ChargebeeResult.Success(
-                    plan
+                    ""
                 )
             )
             Mockito.verify(PlanResource(), times(1)).retrieveAllPlans(queryParam)
@@ -77,14 +71,11 @@ class PlanResourceTest {
     }
     @Test
     fun test_retrievePlansList_error(){
-        val exception = CBException(ErrorDetail("Error"))
-        val queryParam = arrayOf("Standard", "app_store")
-        val lock = CountDownLatch(1)
-        Plan.retrieveAllPlans(queryParam) {
+        Chargebee.retrieveAllPlans(queryParam) {
             when (it) {
                 is ChargebeeResult.Success -> {
                     lock.countDown()
-                    System.out.println("List plans :"+it.data)
+                    print("List plans :"+it.data)
                     MatcherAssert.assertThat(
                         (it.data),
                         Matchers.instanceOf(PlansWrapper::class.java)
@@ -92,12 +83,11 @@ class PlanResourceTest {
                 }
                 is ChargebeeResult.Error -> {
                     lock.countDown()
-                    System.out.println("Error :"+it.exp.message)
+                    print("Error :"+it.exp.message)
                 }
             }
         }
         lock.await()
-
         CoroutineScope(Dispatchers.IO).launch {
             Mockito.`when`(PlanResource().retrieveAllPlans(queryParam)).thenReturn(
                 ChargebeeResult.Error(
@@ -109,19 +99,11 @@ class PlanResourceTest {
     }
     @Test
     fun test_retrievePlan_success(){
-        val plan = Plan(
-            "id", "name", "invoice", 123, 123, "", "",
-            12, 23, "", false, false, "false", false,
-            9, false, "app_store", 7, "", "", false, "", false, false
-        )
-
-        val queryParam = "Standard"
-        val lock = CountDownLatch(1)
-        Plan.retrievePlan(queryParam) {
+        Chargebee.retrievePlan(planId) {
             when (it) {
                 is ChargebeeResult.Success -> {
                     lock.countDown()
-                    System.out.println("List plans :"+it.data)
+                    print("Plan Detail :"+it.data)
                     MatcherAssert.assertThat(
                         (it.data),
                         Matchers.instanceOf(PlansWrapper::class.java)
@@ -129,31 +111,27 @@ class PlanResourceTest {
                 }
                 is ChargebeeResult.Error -> {
                     lock.countDown()
-                    System.out.println("Error :"+it.exp.message)
+                    print("Error :"+it.exp.message)
                 }
             }
         }
         lock.await()
-
         CoroutineScope(Dispatchers.IO).launch {
-            Mockito.`when`(PlanResource().retrievePlan(queryParam)).thenReturn(
+            Mockito.`when`(PlanResource().retrievePlan(planId)).thenReturn(
                 ChargebeeResult.Success(
-                    plan
+                    ""
                 )
             )
-            Mockito.verify(PlanResource(), times(1)).retrievePlan(queryParam)
+            Mockito.verify(PlanResource(), times(1)).retrievePlan(planId)
         }
     }
     @Test
     fun test_retrievePlan_error(){
-        val exception = CBException(ErrorDetail("Error"))
-        val queryParam = "Standard"
-        val lock = CountDownLatch(1)
-        Plan.retrievePlan(queryParam) {
+        Chargebee.retrievePlan(planId) {
             when (it) {
                 is ChargebeeResult.Success -> {
                     lock.countDown()
-                    System.out.println("List plans :"+it.data)
+                    print("List plans :"+it.data)
                     MatcherAssert.assertThat(
                         (it.data),
                         Matchers.instanceOf(PlansWrapper::class.java)
@@ -161,19 +139,51 @@ class PlanResourceTest {
                 }
                 is ChargebeeResult.Error -> {
                     lock.countDown()
-                    System.out.println("Error :"+it.exp.message)
+                    print("Error :"+it.exp.message)
                 }
             }
         }
         lock.await()
-
         CoroutineScope(Dispatchers.IO).launch {
-            Mockito.`when`(PlanResource().retrievePlan(queryParam)).thenReturn(
+            Mockito.`when`(PlanResource().retrievePlan(planId)).thenReturn(
                 ChargebeeResult.Error(
                     exception
                 )
             )
-            Mockito.verify(PlanResource(), times(1)).retrievePlan(queryParam)
+            Mockito.verify(PlanResource(), times(1)).retrievePlan(planId)
+        }
+    }
+
+    @Test
+    fun test_retrievePlansListWithNoParams(){
+        val exception = CBException(ErrorDetail("Error"))
+        val queryParam = arrayOf("")
+        val lock = CountDownLatch(1)
+        Chargebee.retrieveAllPlans() {
+            when (it) {
+                is ChargebeeResult.Success -> {
+                    lock.countDown()
+                    print("List plans :"+it.data)
+                    MatcherAssert.assertThat(
+                        (it.data),
+                        Matchers.instanceOf(PlansWrapper::class.java)
+                    )
+                }
+                is ChargebeeResult.Error -> {
+                    lock.countDown()
+                    print("Error :"+it.exp.message)
+                }
+            }
+        }
+        lock.await()
+        CoroutineScope(Dispatchers.IO).launch {
+            Mockito.`when`(PlanResource().retrieveAllPlans(queryParam)).thenReturn(
+                ChargebeeResult.Success(
+                    ""
+                )
+            )
+            Mockito.verify(PlanResource(), times(1)).retrieveAllPlans(queryParam)
+            Mockito.verify(Chargebee.retrieveAllPlans(){}, times(1))
         }
     }
 }


### PR DESCRIPTION
1. if empty params passed by user. plans api should invoke and fetch plans from server. default limit is 100
2. added limit query param to plans api