### PR TITLE
Build release v1.0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following requirements must be set up before installing Chargebee’s Androi
 The `Chargebee-Android` SDK can be installed by adding below dependency to the `build.gradle` file:
 
 ```kotlin
-implementation 'com.chargebee:chargebee-android:1.0.17'
+implementation 'com.chargebee:chargebee-android:1.0.18'
 ```
 
 ## Example project
@@ -426,7 +426,7 @@ Chargebee is available under the [MIT license](https://opensource.org/licenses/M
   To install Chargebee's Android SDK, add the following dependency to the build.gradle file.
   
   ```
-  implementation 'com.chargebee:chargebee-android:1.0.17'
+  implementation 'com.chargebee:chargebee-android:1.0.18'
   ```
   Example project
   ---------------

--- a/chargebee/build.gradle
+++ b/chargebee/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 30
         versionCode 1
-        versionName "1.0.17"
+        versionName "1.0.18"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
**SDK Improvements**

- Added cache retry mechanism for validating the receipt.(#69 ) 
- Use `CBPurchase.validateReceipt(context: Context, product: CBProduct, customer: CBCustomer? = null, 
   completionCallback: CBCallback.PurchaseCallback<String>)` to validate the receipt if syncing failed with Chargebee after 
   the successful purchase in Google Play Store.