### PR TITLE
Customer object passed on restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,10 @@ The `restorePurchases()` function helps to recover your app user's previous purc
 
 To retrieve **inactive** purchases along with the **active** purchases for your app user, you can call the `restorePurchases()` function with the `includeInActiveProducts` parameter set to `true`. If you only want to restore active subscriptions, set the parameter to `false`. Here is an example of how to use the `restorePurchases()` function in your code with the `includeInActiveProducts` parameter set to `true`.
 
+`CBCustomer` - **Optional object**. Although this is an optional object, we recommend passing the necessary customer details, such as `customerId`, `firstName`, `lastName`, and `email` if it is available before the user subscribes to your App. This ensures that the customer details in your database match the customer details in Chargebee. If the `customerId` is not passed in the customer's details, then the value of `customerId` will be the same as the `SubscriptionId` created in Chargebee.
+
 ```kotlin
-CBPurchase.restorePurchases(context = current activity context, includeInActivePurchases = false, object : CBCallback.RestorePurchaseCallback{
+CBPurchase.restorePurchases(context = current activity context, customer = CBCustomer, includeInActivePurchases = false, object : CBCallback.RestorePurchaseCallback{
       override fun onSuccess(result: List<CBRestoreSubscription>) {
         result.forEach {
           Log.i(javaClass.simpleName, "Successfully restored purchases")

--- a/app/src/main/java/com/chargebee/example/billing/BillingViewModel.kt
+++ b/app/src/main/java/com/chargebee/example/billing/BillingViewModel.kt
@@ -242,8 +242,9 @@ class BillingViewModel : ViewModel() {
     }
 
     fun restorePurchases(context: Context, includeInActivePurchases: Boolean = false) {
+        val customer = CBCustomer("test-restore","","","")
         CBPurchase.restorePurchases(
-            context = context, includeInActivePurchases = includeInActivePurchases,
+            context = context, customer = customer, includeInActivePurchases = includeInActivePurchases,
             completionCallback = object : CBCallback.RestorePurchaseCallback {
                 override fun onSuccess(result: List<CBRestoreSubscription>) {
                     result.forEach {

--- a/chargebee/src/main/java/com/chargebee/android/billingservice/CBPurchase.kt
+++ b/chargebee/src/main/java/com/chargebee/android/billingservice/CBPurchase.kt
@@ -151,16 +151,19 @@ object CBPurchase {
      * And the associated purchases will be synced with Chargebee.
      *
      * @param [context] Current activity context
+     * @param [customer] Optional. Customer Object.
      * @param [includeInActivePurchases] False by default. if true, only active purchases restores and synced with Chargebee.
      * @param [completionCallback] The listener will be called when restore purchase completes.
      */
     @JvmStatic
     fun restorePurchases(
         context: Context,
+        customer: CBCustomer? = null,
         includeInActivePurchases: Boolean = false,
         completionCallback: CBCallback.RestorePurchaseCallback
     ) {
         this.includeInActivePurchases = includeInActivePurchases
+        this.customer = customer
         sharedInstance(context).restorePurchases(completionCallback)
     }
 


### PR DESCRIPTION
**Issue:** 
When customer sync validate receipt with Chargebee on restorePurchase API. The subscription gets created with new customerId instead of associating with the existing customer ID.
**Fixes:**
Introduced new param(CBCustomer object) in restorePurchases API which it helps to pass customer info while restoring the purchases and associate with the same customerId.
