### PR TITLE
fix: pin CodeBuild to Corretto 17 for AGP 7.4.2

### DIFF
--- a/build-config/buildspec-prod.yml
+++ b/build-config/buildspec-prod.yml
@@ -1,7 +1,11 @@
 version: 0.2
 phases:
+  install:
+    runtime-versions:
+      java: corretto17
   build:
     commands:
+      - java -version
       - cd $CODEBUILD_SRC_DIR
       - VERSION=$(echo $CODEBUILD_WEBHOOK_TRIGGER | sed 's/branch\///g')
       - sh $CODEBUILD_SRC_DIR/build-config/sns_util.sh "START" "$VERSION"


### PR DESCRIPTION
## Summary
- CodeBuild for `2.0.0-beta-6` failed because AGP 7.4.2 needs Java 11+ and the prod image was still on Java 8.
- Pin the install runtime to `corretto17` and log `java -version` so the next publish run uses JDK 17.

## Test plan
- [ ] Confirm CodeBuild image supports `runtime-versions` (standard AL2/Ubuntu image). If the project uses a custom image, this change will fail and the image/JAVA_HOME must be updated instead.
- [ ] After merge to `master`, confirm `cb-prod-us-e1-android-sdk-codebuild-project` (`us-east-1`) succeeds.
- [ ] In the build log, `java -version` shows Corretto 17 before `./gradlew`.
- [ ] Staging search for `com.chargebee` returns an `open` repository for `2.0.0-beta-6`.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the production CodeBuild buildspec to install Corretto 17 and log `java -version` before Gradle runs. This supports AGP 7.4.2, which requires Java 11 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->