### PR TITLE
Revert "fix: pin CodeBuild to Corretto 17 for AGP 7.4.2"

### DIFF
--- a/build-config/buildspec-prod.yml
+++ b/build-config/buildspec-prod.yml
@@ -1,11 +1,7 @@
 version: 0.2
 phases:
-  install:
-    runtime-versions:
-      java: corretto17
   build:
     commands:
-      - java -version
       - cd $CODEBUILD_SRC_DIR
       - VERSION=$(echo $CODEBUILD_WEBHOOK_TRIGGER | sed 's/branch\///g')
       - sh $CODEBUILD_SRC_DIR/build-config/sns_util.sh "START" "$VERSION"


### PR DESCRIPTION
Reverts chargebee/chargebee-android#125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Reverts the Corretto 17 configuration from the production buildspec. Removes the initial Java version check so the build uses the existing runtime setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->